### PR TITLE
Filterby dhis2 version before merge

### DIFF
--- a/lib/mergeLaunches.js
+++ b/lib/mergeLaunches.js
@@ -41,6 +41,7 @@ const mergeLaunches = (reporterOptions, mergeOptions = { extendSuitesDescription
 
 const mergeParallelLaunches = async (client, config) => {
   const ciBuildId = process.env.CI_BUILD_ID;
+  const dhis2Version = process.env.DHIS2_VERSION ?? 'master';
   if (!ciBuildId) {
     console.error('For merge parallel launches CI_BUILD_ID must not be empty');
     return;
@@ -49,6 +50,7 @@ const mergeParallelLaunches = async (client, config) => {
     // 1. Send request to get all launches with the same CI_BUILD_ID attribute value
     const params = new URLSearchParams({
       'filter.has.attributeValue': ciBuildId,
+      'filter.has.attributeValue': dhis2Version,
     });
     const launchSearchUrl = `launch?${params.toString()}`;
     const response = await client.restClient.retrieveSyncAPI(launchSearchUrl, {

--- a/lib/mergeLaunches.js
+++ b/lib/mergeLaunches.js
@@ -49,8 +49,8 @@ const mergeParallelLaunches = async (client, config) => {
   try {
     // 1. Send request to get all launches with the same CI_BUILD_ID attribute value
     const params = new URLSearchParams({
-      'filter.has.attributeValue': ciBuildId,
-      'filter.has.attributeValue': dhis2Version,
+      'filter.has.compositeAttribute': ciBuildId,
+      'filter.has.compositeAttribute': dhis2Version,
     });
     const launchSearchUrl = `launch?${params.toString()}`;
     const response = await client.restClient.retrieveSyncAPI(launchSearchUrl, {

--- a/lib/mergeLaunches.js
+++ b/lib/mergeLaunches.js
@@ -47,10 +47,9 @@ const mergeParallelLaunches = async (client, config) => {
     return;
   }
   try {
-    // 1. Send request to get all launches with the same CI_BUILD_ID attribute value
+    // 1. Send request to get all launches with the same CI_BUILD_ID and DHIS2_VERSION attributes value
     const params = new URLSearchParams({
-      'filter.has.compositeAttribute': ciBuildId,
-      'filter.has.compositeAttribute': dhis2Version,
+      'filter.has.compositeAttribute': [ciBuildId, dhis2Version].join(),
     });
     const launchSearchUrl = `launch?${params.toString()}`;
     const response = await client.restClient.retrieveSyncAPI(launchSearchUrl, {


### PR DESCRIPTION
We aim to run our app tests against different dhis2 core versions.
these changes are needed to be able to merge the cypress test results by dhis2 core version and not only ci_builds
see line-listing-app as example (https://github.com/dhis2/line-listing-app/pull/460)